### PR TITLE
Add Popover state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "watch": "./node_modules/.bin/gulp watch",
     "build": "composer install && npm install && ./node_modules/.bin/gulp",
     "serve": "cd public && php -S localhost:8000"
   },

--- a/public/index.php
+++ b/public/index.php
@@ -7,7 +7,8 @@ require_once "../vendor/autoload.php";
  * @return bool
  */
 function sortEpisodes($payload, $sortBy = null) {
-    return array_multisort(array_keys($payload), SORT_ASC, SORT_STRING, $payload);
+    array_multisort(array_keys($payload), SORT_ASC, SORT_STRING, $payload);
+    return $payload;
 };
 
 /**

--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -2,20 +2,40 @@
  * Bootstrap popovers and tooltips
  */
 
-
-var $ = require('jquery')
-
+var $ = require('jquery');
 
 module.exports = function () {
+	let selectedPopover;
 
-    // initialise all popovers
-    $('body').popover({
-        selector: '[data-toggle="popover"]',
-        container: 'body',
-        viewport: { selector: 'body', padding: 20 }
-    })
-    
-    // Initialise Bootstrap tooltips
-    //http://getbootstrap.com/javascript/#tooltips
-    $('[data-toggle="tooltip"]').tooltip()
+	$body = $('body') || {};
+	$popovers = $('[data-toggle="popover"]');
+
+	// initialise all popovers
+	$body.popover({
+		selector: '[data-toggle="popover"]',
+		container: 'body',
+		viewport: {
+			selector: 'body',
+			padding : 20
+		}
+	});
+
+	// https://github.com/twbs/bootstrap/issues/16732
+	$body.on('hidden.bs.popover', function (e) {
+		$(e.target).data("bs.popover").inState.click = false;
+	});
+
+	// set current Popover state
+	$popovers.on('show.bs.popover', function (e) {
+		$target = $(e.currentTarget);
+		if(selectedPopover) {
+			selectedPopover.popover('hide');
+		}
+		selectedPopover = $target;
+	});
+
+	// clear state when hidden
+	$popovers.on('shown.bs.hide', function (e) {
+		selectedPopover = null;
+	});
 }

--- a/templates/page.html
+++ b/templates/page.html
@@ -39,6 +39,8 @@
         </div>
     </footer>
 
+
+
     <script type="text/javascript" src="/resources/compiled/js/main.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Added JS functionality to allow the current popover to be toggled when new popover states are triggered.

---

**Testing**

 Compile assets: `./bin/node_modules/gulp` from command line. Load page in browser. Click an Episode image which should display its popover state. Click another episode image to close the previous popover and to open the popover for most recently clicked image. Click same episode image as previous and popover for this episode should also close

---

**Deployment steps**

Merge branch `popover-state` into `master`

Compile assets: `./bin/node_modules/gulp`
